### PR TITLE
Resolve Sass deprecation warnings (Sass 3.5+)

### DIFF
--- a/stylesheets/encode/api/_json.scss
+++ b/stylesheets/encode/api/_json.scss
@@ -12,9 +12,14 @@
 /// @require {function} _json-encode--bool
 @function json-encode($value) {
   $type: type-of($value);
+  $function: '_json-encode--#{$type}';
+
+  @if function-exists('get-function') {
+    $function: get-function($function);
+  }
 
   @if function-exists('_json-encode--#{$type}') {
-    @return call('_json-encode--#{$type}', $value);
+    @return call($function, $value);
   }
 
   @error 'Unknown type for #{$value} (#{$type}).';


### PR DESCRIPTION
Resolve Sass deprecation warnings that appear in Sass 3.5+:

**Example warnings:**
```
DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("-json-encode--map")) instead.

DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("-json-encode--color")) instead.
```