### PR TITLE
Add support for calculation type

### DIFF
--- a/stylesheets/encode/encode.scss
+++ b/stylesheets/encode/encode.scss
@@ -9,6 +9,7 @@
 @import 'types/number';
 @import 'types/string';
 @import 'types/null';
+@import 'types/calculation';
 
 // Public API
 @import 'api/json';

--- a/stylesheets/encode/types/_calculation.scss
+++ b/stylesheets/encode/types/_calculation.scss
@@ -1,0 +1,8 @@
+/// Encode a calculation to JSON
+/// @access private
+/// @param {String} $string - string to be encoded
+/// @return {String} - encoded string
+/// @require {function} _proof-quote
+@function _json-encode--calculation($calculation) {
+  @return _proof-quote($calculation);
+}

--- a/stylesheets/encode/types/_calculation.scss
+++ b/stylesheets/encode/types/_calculation.scss
@@ -1,6 +1,6 @@
 /// Encode a calculation to JSON
 /// @access private
-/// @param {String} $string - string to be encoded
+/// @param {String} $calculation - calculation to be encoded
 /// @return {String} - encoded string
 /// @require {function} _proof-quote
 @function _json-encode--calculation($calculation) {

--- a/test/encode/_index.scss
+++ b/test/encode/_index.scss
@@ -9,6 +9,7 @@
 @import 'types/list';
 @import 'types/map';
 @import 'types/null';
+@import 'types/calculation';
 
 // API
 @import 'api/json';

--- a/test/encode/types/_calculation.scss
+++ b/test/encode/types/_calculation.scss
@@ -1,0 +1,6 @@
+@include describe('The _json-encode--calculation function') {
+  @include it('should return a quoted calculation') {
+    @include should(expect(_json-encode--calculation('calc(100vw - 10px)')), to(equal('"calc(100vw - 10px)"')));
+    @include should(expect(_json-encode--calculation('clamp(100px, 100vw, 1000px)')), to(equal('"clamp(100px, 100vw, 1000px)"')));
+  }
+}


### PR DESCRIPTION
Adds support for the `calculation` type added in dart-sass 1.40, used for things like `calc()` and `clamp()`.

Just outputs them as quoted strings as that's probably the only sensible way to handle them.